### PR TITLE
Add ASan Support

### DIFF
--- a/clean.sh
+++ b/clean.sh
@@ -13,7 +13,5 @@ rm -rf $SRC_DIR/state-observation/build
 rm -rf $SRC_DIR/hrpsys-state-observation/build
 rm -rf $SRC_DIR/hmc2/build
 rm -rf $SRC_DIR/choreonoid/build
-
-
-
-
+rm -rf $SRC_DIR/sch-core/build
+rm -rf $SRC_DIR/trap-fpe/build

--- a/install.sh
+++ b/install.sh
@@ -8,6 +8,7 @@ RUNNINGSCRIPT="$0"
 trap 'err_report $LINENO $FILENAME $RUNNINGSCRIPT; exit 1' ERR
 
 export PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig
+export PATH=$PREFIX/bin:$PATH
 
 if [ "$ENABLE_ASAN" -eq 1 ]; then
     BUILD_TYPE=RelWithDebInfo
@@ -47,7 +48,7 @@ fi
 ./configure --prefix=$PREFIX --without-doxygen $EXTRA_OPTION
 $SUDO make -j$MAKE_THREADS_NUMBER install
 
-cmake_install_with_option "openhrp3" "-DCOMPILE_JAVA_STUFF=OFF -DBUILD_GOOGLE_TEST=$BUILD_GOOGLE_TEST"
+cmake_install_with_option "openhrp3" "-DCOMPILE_JAVA_STUFF=OFF -DBUILD_GOOGLE_TEST=$BUILD_GOOGLE_TEST -DOPENRTM_DIR=$PREFIX"
 
 if [ "$INTERNAL_MACHINE" -eq 0 ]; then
     if [ "$UBUNTU_VER" != "16.04" ]; then

--- a/install.sh
+++ b/install.sh
@@ -12,26 +12,25 @@ export PATH=$PREFIX/bin:$PATH
 
 if [ "$ENABLE_ASAN" -eq 1 ]; then
     BUILD_TYPE=RelWithDebInfo
-    ASAN_OPTIONS=" -DCMAKE_CXX_FLAGS_RELWITHDEBINFO=\"-O2 -g -DNDEBUG -fsanitize=address\" -DCMAKE_C_FLAGS_RELWITHDEBINFO=\"-O2 -g -DNDEBUG -fsanitize=address\""
+    ASAN_OPTIONS=(-DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O2 -g -DNDEBUG -fsanitize=address" -DCMAKE_C_FLAGS_RELWITHDEBINFO="-O2 -g -DNDEBUG -fsanitize=address")
 else
-    ASAN_OPTIONS=
+    ASAN_OPTIONS=()
 fi
 
 cmake_install_with_option() {
+    SUBDIR="$1"
+    shift
+
     # check existence of the build directory
-    if [ ! -d "$SRC_DIR/$1/build" ]; then
-        mkdir "$SRC_DIR/$1/build"
+    if [ ! -d "$SRC_DIR/$SUBDIR/build" ]; then
+        mkdir "$SRC_DIR/$SUBDIR/build"
     fi
-    cd "$SRC_DIR/$1/build"
+    cd "$SRC_DIR/$SUBDIR/build"
 
-    COMMON_OPTIONS="-DCMAKE_INSTALL_PREFIX=$PREFIX -DCMAKE_BUILD_TYPE=$BUILD_TYPE"$ASAN_OPTIONS
-    echo cmake $COMMON_OPTIONS
+    COMMON_OPTIONS=(-DCMAKE_INSTALL_PREFIX="$PREFIX" -DCMAKE_BUILD_TYPE="$BUILD_TYPE" "${ASAN_OPTIONS[@]}")
+    echo cmake $(printf "'%s' " "${COMMON_OPTIONS[@]}" "$@") ..
 
-    if [ $# = 1 ]; then
-        eval "cmake $COMMON_OPTIONS .."
-    else
-        eval "cmake $COMMON_OPTIONS $2 .."
-    fi
+    cmake "${COMMON_OPTIONS[@]}" "$@" ..
 
     $SUDO make -j$MAKE_THREADS_NUMBER install
 }
@@ -41,63 +40,65 @@ if [ ! -e configure ]; then
     ./build/autogen
 fi
 if [ $BUILD_TYPE != "Release" ]; then
-    EXTRA_OPTION="--enable-debug"
+    EXTRA_OPTION=(--enable-debug)
 else
-    EXTRA_OPTION=
+    EXTRA_OPTION=()
 fi
-./configure --prefix=$PREFIX --without-doxygen $EXTRA_OPTION
+./configure --prefix="$PREFIX" --without-doxygen "${EXTRA_OPTION[@]}"
 
 if [ "$ENABLE_ASAN" -eq 1 ]; then
     # We set -fsanitize=address here, after configure, because this
     # flag interferes with detecting the flags needed for pthreads,
     # causing problems later on.
-    EXTRA_OPTION="CXXFLAGS='-O2 -g3 -fsanitize=address' CFLAGS='-O2 -g3 -fsanitize=address'"
+    EXTRA_OPTION=(CXXFLAGS="-O2 -g3 -fsanitize=address" CFLAGS="-O2 -g3 -fsanitize=address")
     # Report, but don't fail on, leaks in program samples during build.
     export LSAN_OPTIONS="exitcode=0"
 else
-    EXTRA_OPTION=
+    EXTRA_OPTION=()
 fi
-eval "$SUDO make -j$MAKE_THREADS_NUMBER install $EXTRA_OPTION"
+$SUDO make -j$MAKE_THREADS_NUMBER install "${EXTRA_OPTION[@]}"
 
-cmake_install_with_option "openhrp3" "-DCOMPILE_JAVA_STUFF=OFF -DBUILD_GOOGLE_TEST=$BUILD_GOOGLE_TEST -DOPENRTM_DIR=$PREFIX"
+cmake_install_with_option "openhrp3" -DCOMPILE_JAVA_STUFF=OFF -DBUILD_GOOGLE_TEST="$BUILD_GOOGLE_TEST" -DOPENRTM_DIR="$PREFIX"
 
 if [ "$INTERNAL_MACHINE" -eq 0 ]; then
     if [ "$UBUNTU_VER" != "16.04" ]; then
 	cmake_install_with_option "octomap-$OCTOMAP_VERSION"
     fi
-    EXTRA_OPTION=
+    EXTRA_OPTION=()
 else
-    EXTRA_OPTION="-DINSTALL_HRPIO=OFF"
+    EXTRA_OPTION=(-DINSTALL_HRPIO=OFF)
 fi
-cmake_install_with_option "hrpsys-base" "-DCOMPILE_JAVA_STUFF=OFF -DBUILD_KALMAN_FILTER=OFF -DBUILD_STABILIZER=OFF -DENABLE_DOXYGEN=OFF $EXTRA_OPTION"
-cmake_install_with_option "HRP2" "-DROBOT_NAME=HRP2KAI"
-cmake_install_with_option "HRP2KAI"
-cmake_install_with_option "HRP5P"
+cmake_install_with_option hrpsys-base -DCOMPILE_JAVA_STUFF=OFF -DBUILD_KALMAN_FILTER=OFF -DBUILD_STABILIZER=OFF -DENABLE_DOXYGEN=OFF "${EXTRA_OPTION[@]}"
+cmake_install_with_option HRP2 -DROBOT_NAME=HRP2KAI
+cmake_install_with_option HRP2KAI
+cmake_install_with_option HRP5P
 if [ "$INTERNAL_MACHINE" -eq 0 ]; then
-    EXTRA_OPTION=
+    EXTRA_OPTION=()
 else
-    EXTRA_OPTION="-DGENERATE_FILES_FOR_SIMULATION=OFF"
+    EXTRA_OPTION=(-DGENERATE_FILES_FOR_SIMULATION=OFF)
 fi
-cmake_install_with_option "sch-core"
-cmake_install_with_option "hmc2" "-DCOMPILE_JAVA_STUFF=OFF $EXTRA_OPTION"
-cmake_install_with_option "hrpsys-humanoid" "-DCOMPILE_JAVA_STUFF=OFF $EXTRA_OPTION"
-cmake_install_with_option "hrpsys-private"
-cmake_install_with_option "state-observation" "-DCMAKE_INSTALL_LIBDIR=lib"
-cmake_install_with_option "hrpsys-state-observation"
+cmake_install_with_option sch-core
+cmake_install_with_option hmc2 -DCOMPILE_JAVA_STUFF=OFF "${EXTRA_OPTION[@]}"
+cmake_install_with_option hrpsys-humanoid -DCOMPILE_JAVA_STUFF=OFF "${EXTRA_OPTION[@]}"
+cmake_install_with_option hrpsys-private
+cmake_install_with_option state-observation -DCMAKE_INSTALL_LIBDIR=lib
+cmake_install_with_option hrpsys-state-observation
 if [ "$INTERNAL_MACHINE" -eq 0 ]; then
     if [ "$IS_VIRTUAL_BOX" -eq 1 ]; then
-      CHOREONOID_CMAKE_CXX_FLAGS="\"-DJOYSTICK_DEVICE_PATH=\\\"/dev/input/js1\\\"\" $CHOREONOID_CMAKE_CXX_FLAGS" #mouse integration uses /dev/input/js1 in virtualbox
+      CHOREONOID_CMAKE_CXX_FLAGS="-DJOYSTICK_DEVICE_PATH=\"/dev/input/js1\" $CHOREONOID_CMAKE_CXX_FLAGS" #mouse integration uses /dev/input/js1 in virtualbox
     fi
-    cmake_install_with_option "choreonoid" "-DENABLE_CORBA=ON -DBUILD_CORBA_PLUGIN=ON -DBUILD_OPENRTM_PLUGIN=ON -DBUILD_PCL_PLUGIN=ON -DBUILD_OPENHRP_PLUGIN=ON -DBUILD_GRXUI_PLUGIN=ON -DBODY_CUSTOMIZERS='$SRC_DIR/HRP2/customizer/HRP2Customizer;$SRC_DIR/HRP5P/customizer/HRP5PCustomizer' -DBUILD_DRC_USER_INTERFACE_PLUGIN=ON -DCMAKE_CXX_FLAGS='$CHOREONOID_CMAKE_CXX_FLAGS'"
+    # FIXME?: This doesn't look right.  CMAKE_CXX_FLAGS is ignored
+    # unless CMAKE_BUILD_TYPE is empty, which it is not by default.
+    cmake_install_with_option "choreonoid" -DENABLE_CORBA=ON -DBUILD_CORBA_PLUGIN=ON -DBUILD_OPENRTM_PLUGIN=ON -DBUILD_PCL_PLUGIN=ON -DBUILD_OPENHRP_PLUGIN=ON -DBUILD_GRXUI_PLUGIN=ON -DBODY_CUSTOMIZERS="$SRC_DIR/HRP2/customizer/HRP2Customizer;$SRC_DIR/HRP5P/customizer/HRP5PCustomizer" -DBUILD_DRC_USER_INTERFACE_PLUGIN=ON -DCMAKE_CXX_FLAGS="$CHOREONOID_CMAKE_CXX_FLAGS"
     if [ "$UBUNTU_VER" != "16.04" ]; then
-	cmake_install_with_option "trap-fpe" "-DTRAP_FPE_BLACKLIST=$DRCUTIL/trap-fpe.blacklist.ubuntu1404"
+	cmake_install_with_option trap-fpe "-DTRAP_FPE_BLACKLIST=$DRCUTIL/trap-fpe.blacklist.ubuntu1404"
     else
-	cmake_install_with_option "trap-fpe" "-DTRAP_FPE_BLACKLIST=$DRCUTIL/trap-fpe.blacklist.ubuntu1604"
+	cmake_install_with_option trap-fpe "-DTRAP_FPE_BLACKLIST=$DRCUTIL/trap-fpe.blacklist.ubuntu1604"
     fi
 else
-    cmake_install_with_option "flexiport" "-DBUILD_DOCUMENTATION=OFF"
-    cmake_install_with_option "hokuyoaist" "-DBUILD_DOCUMENTATION=OFF -DBUILD_PYTHON_BINDINGS=OFF"
-    cmake_install_with_option "rtchokuyoaist" "-DBUILD_DOCUMENTATION=OFF"
+    cmake_install_with_option flexiport -DBUILD_DOCUMENTATION=OFF
+    cmake_install_with_option hokuyoaist -DBUILD_DOCUMENTATION=OFF -DBUILD_PYTHON_BINDINGS=OFF
+    cmake_install_with_option rtchokuyoaist -DBUILD_DOCUMENTATION=OFF
 fi
 
 echo "add the following environmental variable settings to your .bashrc"


### PR DESCRIPTION
These commits make ENABLE_ASAN=1 work.  The last commit (2d9eb4f) may be somewhat invasive and obscure, so please make sure you can understand and maintain it.  It basically replaces
EXTRA_OPTION="-DFOO='bar baz' -DBAR='abc def'"
with arrays, like
EXTRA_OPTION=(-DFOO="bar baz" -DBAR="abc def")
so that troubles like "Why isn't this argument quoted?  I thought it would be quoted :(" are a lot less likely.