### PR TITLE
Split out savedbg

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -44,7 +44,7 @@ build_install() {
 }
 
 built_dirs=
-build_install "openhrp3" "hrpsys-base" "HRP2" "HRP2KAI" "HRP5P" "sch-core" "hmc2" "hrpsys-private" "hrpsys-humanoid" "state-observation" "hrpsys-state-observation"
+build_install "openhrp3" "hrpsys-base" "HRP2" "HRP2KAI" "HRP5P" "sch-core" "hmc2" "hrpsys-private" "hrpsys-humanoid" "state-observation" "hrpsys-state-observation" "savedbg"
 
 if [ "$INTERNAL_MACHINE" -eq 0 ]; then
 build_install "choreonoid" "trap-fpe"

--- a/checkout.sh
+++ b/checkout.sh
@@ -19,6 +19,9 @@ cd $SRC_DIR
 
 pull_source OpenRTM-aist openhrp3 hrpsys-base sch-core hmc2 hrpsys-private hrpsys-humanoid HRP2 HRP2KAI HRP5P state-observation hrpsys-state-observation
 
+if [ "$ENABLE_SAVEDBG" -eq 1 ]; then
+    pull_source savedbg
+fi
 if [ "$INTERNAL_MACHINE" -eq 0 ]; then
     GIT_SSL_NO_VERIFY=1 pull_source choreonoid
     pull_source choreonoid/ext/hrpcnoid

--- a/clean.sh
+++ b/clean.sh
@@ -17,3 +17,4 @@ rm -rf $SRC_DIR/hmc2/build
 rm -rf $SRC_DIR/choreonoid/build
 rm -rf $SRC_DIR/sch-core/build
 rm -rf $SRC_DIR/trap-fpe/build
+rm -rf $SRC_DIR/savedbg/build

--- a/config.sh.sample
+++ b/config.sh.sample
@@ -13,6 +13,7 @@ export ENABLE_ASAN=0
 export IS_VIRTUAL_BOX=0
 export BUILD_TRAP_FPE=0
 export ROBOT_HOSTNAME=localhost
+export ENABLE_SAVEDBG=0
 
 /bin/ping atom.a01.aist.go.jp -c 1 &> /dev/null
 if [ $? -ne 0 ] 

--- a/getsource.sh
+++ b/getsource.sh
@@ -37,6 +37,9 @@ get_source "git clone --recursive https://github.com/mehdi-benallegue/state-obse
 get_source "git clone https://github.com/jrl-umi3218/hmc2" hmc2
 get_source "git clone https://github.com/jrl-umi3218/hrpsys-humanoid" hrpsys-humanoid
 get_source "git clone --recursive https://github.com/mehdi-benallegue/sch-core" sch-core
+if [ "$ENABLE_SAVEDBG" -eq 1 ]; then
+    get_source "git clone https://bitbucket.org/jun0/savedbg" savedbg
+fi
 if [ "$INTERNAL_MACHINE" -eq 0 ]; then
     if [ "$UBUNTU_VER" != "16.04" ]; then
 	if [ ! -e octomap-$OCTOMAP_VERSION ]; then

--- a/install.sh
+++ b/install.sh
@@ -86,10 +86,13 @@ else
 fi
 cmake_install_with_option sch-core
 cmake_install_with_option hmc2 -DCOMPILE_JAVA_STUFF=OFF "${EXTRA_OPTION[@]}"
-cmake_install_with_option hrpsys-humanoid -DCOMPILE_JAVA_STUFF=OFF "${EXTRA_OPTION[@]}"
+cmake_install_with_option hrpsys-humanoid -DCOMPILE_JAVA_STUFF=OFF -DENABLE_SAVEDBG=$ENABLE_SAVEDBG "${EXTRA_OPTION[@]}"
 cmake_install_with_option hrpsys-private
 cmake_install_with_option state-observation -DCMAKE_INSTALL_LIBDIR=lib
 cmake_install_with_option hrpsys-state-observation
+if [ "$ENABLE_SAVEDBG" -eq 1 ]; then
+    cmake_install_with_option savedbg -DSAVEDBG_FRONTEND_NAME=savedbg-hrp -DSAVEDBG_FRONTEND_ARGS="-P 'dpkg -l > dpkg' -f '$PREFIX/share/robot-sources.tar.bz2'"
+fi
 if [ "$INTERNAL_MACHINE" -eq 0 ]; then
     if [ "$IS_VIRTUAL_BOX" -eq 1 ]; then
       CHOREONOID_CMAKE_CXX_FLAGS="-DJOYSTICK_DEVICE_PATH=\"/dev/input/js1\" $CHOREONOID_CMAKE_CXX_FLAGS" #mouse integration uses /dev/input/js1 in virtualbox

--- a/setupenv.sh
+++ b/setupenv.sh
@@ -38,6 +38,10 @@ sudo apt-get -y install libxml2-dev libsdl-dev libglew-dev libopencv-dev libcvau
 #hmc2
 sudo apt-get -y install libyaml-dev libncurses5-dev
 
+if [ "$ENABLE_SAVEDBG" -eq 1 ]; then
+    sudo apt-get -y install elfutils
+fi
+
 if [ "$INTERNAL_MACHINE" -eq 0 ]; then
 cd $SRC_DIR/choreonoid/misc/script
 ./install-requisites-ubuntu-$UBUNTU_VER.sh

--- a/task.sh
+++ b/task.sh
@@ -45,7 +45,15 @@ rm -rf PointCloud
 rm -f *.tau
 rm -f *.qRef
 rm -f *.log
-LD_PRELOAD="${ASAN_LIB}:${WORKSPACE}/openrtp/lib/libtrap_fpe.so" CNOID_TASK_TRY_FULL_AUTO_MODE=1 choreonoid ${TASK}.cnoid --start-simulation &
+
+if [ "$ENABLE_SAVEDBG" -eq 1 ]
+then
+    SAVEDBG_HRP=savedbg-hrp
+else
+    SAVEDBG_HRP=
+fi
+
+$SAVEDBG_HRP LD_PRELOAD="${ASAN_LIB}:${WORKSPACE}/openrtp/lib/libtrap_fpe.so" CNOID_TASK_TRY_FULL_AUTO_MODE=1 choreonoid ${TASK}.cnoid --start-simulation &
 CHOREONOID=$(jobs -p %+)
 
 for ((i=0; i<900; i++)); do


### PR DESCRIPTION
savedbg 機能を hrpsys-humanoid から専用のリポに移し、build.sh/install.sh から使用不使用を切り替えられるようにしました。ENABLE_SAVEDBG=1 と設定すれば jenkins でもコアダンプなどのデバッグ情報をまとめた tarball ができるようになります。hrpsys-humanoid 側の変更と合わせて導入して下さい。

ただ、tarball が溜まり過ぎたら削除するような機能は実装できていません。そもそもどこに溜めておけば良いのかもよく分かりませんし… (現時点では working directory に溜まっていくようになっています)
Jenkins の方に古いビルドを消していく機能があるようなので、tarball を artifact に指定して、古いファイルのお掃除は Jenkins に任せる、という方針ではいけませんか?
https://support.cloudbees.com/hc/en-us/articles/215549798-Deleting-Old-Builds-Best-Strategy-for-Cleanup-and-disk-space-management