### PR TITLE
Move to the custom build directory

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -27,7 +27,7 @@ cd ../
 build_install() {
     for dir_name in $@; do
 	if [ -e $dir_name ]; then
-            cd "$dir_name/build"
+            cd "$dir_name/$BUILD_SUBDIR"
 	    echo -n "building $dir_name ... "
 	    if [ "${VERBOSE-0}" -eq 0 ]; then
 		$SUDO make -j$MAKE_THREADS_NUMBER install > $SRC_DIR/${dir_name}.log 2>&1

--- a/clean.sh
+++ b/clean.sh
@@ -4,17 +4,17 @@ source config.sh
 
 cd $SRC_DIR/OpenRTM-aist
 make maintainer-clean
-rm -rf $SRC_DIR/openhrp3/build
-rm -rf $SRC_DIR/HRP2/build
-rm -rf $SRC_DIR/HRP2KAI/build
-rm -rf $SRC_DIR/HRP5P/build
-rm -rf $SRC_DIR/hrpsys-base/build
-rm -rf $SRC_DIR/hrpsys-private/build
-rm -rf $SRC_DIR/hrpsys-humanoid/build
-rm -rf $SRC_DIR/state-observation/build
-rm -rf $SRC_DIR/hrpsys-state-observation/build
-rm -rf $SRC_DIR/hmc2/build
-rm -rf $SRC_DIR/choreonoid/build
-rm -rf $SRC_DIR/sch-core/build
-rm -rf $SRC_DIR/trap-fpe/build
-rm -rf $SRC_DIR/savedbg/build
+rm -rf $SRC_DIR/openhrp3/$BUILD_SUBDIR
+rm -rf $SRC_DIR/HRP2/$BUILD_SUBDIR
+rm -rf $SRC_DIR/HRP2KAI/$BUILD_SUBDIR
+rm -rf $SRC_DIR/HRP5P/$BUILD_SUBDIR
+rm -rf $SRC_DIR/hrpsys-base/$BUILD_SUBDIR
+rm -rf $SRC_DIR/hrpsys-private/$BUILD_SUBDIR
+rm -rf $SRC_DIR/hrpsys-humanoid/$BUILD_SUBDIR
+rm -rf $SRC_DIR/state-observation/$BUILD_SUBDIR
+rm -rf $SRC_DIR/hrpsys-state-observation/$BUILD_SUBDIR
+rm -rf $SRC_DIR/hmc2/$BUILD_SUBDIR
+rm -rf $SRC_DIR/choreonoid/$BUILD_SUBDIR
+rm -rf $SRC_DIR/sch-core/$BUILD_SUBDIR
+rm -rf $SRC_DIR/trap-fpe/$BUILD_SUBDIR
+rm -rf $SRC_DIR/savedbg/$BUILD_SUBDIR

--- a/packsrc.sh
+++ b/packsrc.sh
@@ -32,17 +32,17 @@ packsrc () {
     cd $SRC_DIR
     revs "$@" > revisions 2>&1
     tar -jcf "robot-sources.tar.bz2" \
-        --exclude-vcs --exclude=build --exclude=.libs --exclude='*.o' \
+        --exclude-vcs --exclude="$BUILD_SUBDIR" --exclude-tag-all="CMakeCache.txt" --exclude=.libs --exclude='*.o' \
         --exclude='*.lo' --exclude='*.a' --exclude='*.la' \
         revisions \
         "$@" \
         $(for d in $*; do \
               [ -f "$d/config.log" ] \
                   && echo "$d/config.log"; \
-              [ -f "$d/build/config.log" ] \
-                  && echo "$d/build/config.log"; \
-              [ -f "$d/build/CMakeCache.txt" ] \
-                  && echo "$d/build/CMakeCache.txt"; \
+              [ -f "$d/$BUILD_SUBDIR/config.log" ] \
+                  && echo "$d/$BUILD_SUBDIR/config.log"; \
+              [ -f "$d/$BUILD_SUBDIR/CMakeCache.txt" ] \
+                  && echo "$d/$BUILD_SUBDIR/CMakeCache.txt"; \
               echo "$d.log"; \
           done)
     rm -f revisions

--- a/test.sh
+++ b/test.sh
@@ -3,7 +3,7 @@ cd $SRC_DIR
 
 ctest_exec() {
     for dir_name in $@; do
-        cd "$dir_name/build"
+        cd "$dir_name/$BUILD_SUBDIR"
 	echo -n "testing $dir_name ... "
         ctest --verbose --test-action Test || true
         cd ../../


### PR DESCRIPTION
Move all the corresponding script to the cutom build directory.

Also modify the packsrc script to comply with the case of several build directories (any directory containing the file CMakeCache.txt is ignored.