### PR TITLE
Modify the scripts to improve behavior and usability

### DIFF
--- a/config.sh.sample
+++ b/config.sh.sample
@@ -17,41 +17,4 @@ export ROBOT_HOSTNAME=localhost
 export ENABLE_SAVEDBG=0
 
 ######## Please don't edit from here ########
-case $(lsb_release -is) in
-    Debian)
-        DIST_KIND=debian
-	DIST_FULL_VER="$(lsb_release -rs)"
-	DIST_VER="${DIST_FULL_VER:0:1}"
-	INTERNAL_MACHINE=1
-        ;;
-    Ubuntu)
-        DIST_KIND=ubuntu
-	DIST_VER="$(lsb_release -rs)"
-        ;;
-    *)
-        echo 1>&2 "config.sh: error: unknown distribution: $(lsb_release -is)"
-        exit 1
-        ;;
-esac
-
-case $(uname -m) in
-    x86_64)
-        ARCH_BITS=64
-        ;;
-    x86|i[3-6]86)
-        ARCH_BITS=32
-        ;;
-    *)
-        echo 1>&2 "config.sh: error: unknown architecture: $(uname -m)"
-        exit 1
-        ;;
-esac
-
-BUILD_GOOGLE_TEST=ON
-
-err_report() {
-    echo "Error on line $2:$1"
-    echo "Stopping the script $(basename "$3")."
-}
-
-
+source definitions.sh

--- a/definitions.sh
+++ b/definitions.sh
@@ -1,0 +1,37 @@
+######## Please don't edit from here ########
+case $(lsb_release -is) in
+    Debian)
+        DIST_KIND=debian
+	DIST_FULL_VER="$(lsb_release -rs)"
+	DIST_VER="${DIST_FULL_VER:0:1}"
+	INTERNAL_MACHINE=1
+        ;;
+    Ubuntu)
+        DIST_KIND=ubuntu
+	DIST_VER="$(lsb_release -rs)"
+        ;;
+    *)
+        echo 1>&2 "config.sh: error: unknown distribution: $(lsb_release -is)"
+        exit 1
+        ;;
+esac
+
+case $(uname -m) in
+    x86_64)
+        ARCH_BITS=64
+        ;;
+    x86|i[3-6]86)
+        ARCH_BITS=32
+        ;;
+    *)
+        echo 1>&2 "config.sh: error: unknown architecture: $(uname -m)"
+        exit 1
+        ;;
+esac
+
+BUILD_GOOGLE_TEST=ON
+
+err_report() {
+    echo "Error on line $2:$1"
+    echo "Stopping the script $(basename "$3")."
+}

--- a/packsrc.sh
+++ b/packsrc.sh
@@ -31,19 +31,18 @@ packsrc () {
     echo "packing source trees"
     cd $SRC_DIR
     revs "$@" > revisions 2>&1
-    tar -jcf "robot-sources.tar.bz2" \
-        --exclude-vcs --exclude="$BUILD_SUBDIR" --exclude-tag-all="CMakeCache.txt" --exclude=.libs --exclude='*.o' \
-        --exclude='*.lo' --exclude='*.a' --exclude='*.la' \
-        revisions \
-        "$@" \
-        $(for d in $*; do \
+    { find $@  \(  \! \( -iwholename "*/.git*" -prune  -o  -iwholename "*/.svn*" -prune  -o -iwholename "./$BUILD_SUBDIR/" -prune -o  -exec test -e '{}/CMakeCache.txt' \; -prune -o  -name '*.o' \
+      -o -name '*.lo' -o -name '*.a' -o -name '*.la' \) -a -type f \) -print0;
+    for d in $*; do \
               [ -f "$d/config.log" ] \
-                  && echo "$d/config.log"; \
+                  && printf "$d/config.log\0"; \
               [ -f "$d/$BUILD_SUBDIR/config.log" ] \
-                  && echo "$d/$BUILD_SUBDIR/config.log"; \
+                  && printf  "$d/$BUILD_SUBDIR/config.log\0"; \
               [ -f "$d/$BUILD_SUBDIR/CMakeCache.txt" ] \
-                  && echo "$d/$BUILD_SUBDIR/CMakeCache.txt"; \
-              echo "$d.log"; \
-          done)
+                  && printf  "$d/$BUILD_SUBDIR/CMakeCache.txt\0"; \
+              printf "$d.log\0";\
+    done;
+    printf "revisions\0" ; } \
+    | tar -jcf "robot-sources.tar.bz2" --null -T -
     rm -f revisions
 }

--- a/packsrc.sh
+++ b/packsrc.sh
@@ -40,7 +40,7 @@ packsrc () {
                   && printf  "$d/$BUILD_SUBDIR/config.log\0"; \
               [ -f "$d/$BUILD_SUBDIR/CMakeCache.txt" ] \
                   && printf  "$d/$BUILD_SUBDIR/CMakeCache.txt\0"; \
-              printf "$d.log\0";\
+              printf "$d.log\0"; \
     done;
     printf "revisions\0" ; } \
     | tar -jcf "robot-sources.tar.bz2" --null -T -


### PR DESCRIPTION
1)  Modify the script of packsrc to be able to add CMakeCache.txt and config.log
-This allows to exclude build directories and still be able to add CMakeCache.txt and Config.log (there was already an instruction to do that but it was ignored by the --exclude predicate)
2)  Move the definitions that must not be edited to a separate file called definitions.sh
-Without this update, every time this non editable part is modified, we need to copy again a new config.sh if we don't change our personal configuration variable.