### PR TITLE
[drcutil] Add BUILD_SUBDIR to hrp2001 config files

### DIFF
--- a/config.sh.hrp2001c
+++ b/config.sh.hrp2001c
@@ -4,6 +4,7 @@ export SUDO=sudo
 export INTERNAL_MACHINE=1
 export MAKE_THREADS_NUMBER=8
 export BUILD_TYPE=RelWithDebInfo
+export BUILD_SUBDIR=build
 export OCTOMAP_VERSION=1.8.0
 export ENABLE_ASAN=0
 export IS_VIRTUAL_BOX=0

--- a/config.sh.hrp2001t
+++ b/config.sh.hrp2001t
@@ -4,6 +4,7 @@ export SUDO=
 export INTERNAL_MACHINE=0
 export MAKE_THREADS_NUMBER=8
 export BUILD_TYPE=RelWithDebInfo
+export BUILD_SUBDIR=build
 export OCTOMAP_VERSION=1.8.0
 export ENABLE_ASAN=0
 export IS_VIRTUAL_BOX=0


### PR DESCRIPTION
BUILD_SUBDIR variable seems to be absent from config.hrp2001t/c