### PR TITLE
Fix build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -16,9 +16,9 @@ build_install_OpenRTM-aist() {
     if [ `cat svn.log | wc -l` != 2 ]; then
         echo -n "building OpenRTM-aist ... "
 	if [ "${VERBOSE-0}" -eq 0 ]; then
-	    $SUDO make -j$MAKE_THREADS_NUMBER "${ASAN_FLAGS[@]}" install > $SRC_DIR/OpenRTM-aist.log 2>&1
+	    $SUDO make -j$MAKE_THREADS_NUMBER "${SAN_FLAGS[@]}" install > $SRC_DIR/OpenRTM-aist.log 2>&1
 	else
-	    $SUDO make -j$MAKE_THREADS_NUMBER "${ASAN_FLAGS[@]}" install 2>&1 | tee $SRC_DIR/OpenRTM-aist.log
+	    $SUDO make -j$MAKE_THREADS_NUMBER "${SAN_FLAGS[@]}" install 2>&1 | tee $SRC_DIR/OpenRTM-aist.log
 	fi
 
         if [ "$?" -eq 0 ]
@@ -37,9 +37,9 @@ build_install() {
         cd "$dir_name/$BUILD_SUBDIR"
 	echo -n "building $dir_name ... "
 	if [ "${VERBOSE-0}" -eq 0 ]; then
-	    $SUDO make -j$MAKE_THREADS_NUMBER "${SAN_FLAGS[@]}" install > $SRC_DIR/${dir_name}.log 2>&1
+	    $SUDO make -j$MAKE_THREADS_NUMBER install > $SRC_DIR/${dir_name}.log 2>&1
 	else
-	    $SUDO make -j$MAKE_THREADS_NUMBER "${SAN_FLAGS[@]}" install 2>&1 | tee $SRC_DIR/${dir_name}.log
+	    $SUDO make -j$MAKE_THREADS_NUMBER install 2>&1 | tee $SRC_DIR/${dir_name}.log
 	fi
 	if [ "$?" -eq 0 ]
 	then


### PR DESCRIPTION
SAN_FLAGS should be used in building autoconf-based packages, not
cmake-based ones.  Plus, the new flags is SAN_FLAGS, not ASAN_FLAGS.