### PR TITLE
remove libglpk-dev, because old library is unstable calculation (causes often assert)

### DIFF
--- a/setupenv.sh
+++ b/setupenv.sh
@@ -128,9 +128,9 @@ setupenv_state-observation() {
 
 setupenv_hmc2() {
     if [ $OSNAME = "Darwin" ]; then
-	brew install libyaml libglpk
+	brew install libyaml
     else
-	sudo apt-get -y install libglpk-dev libyaml-dev libncurses5-dev
+	sudo apt-get -y install libyaml-dev libncurses5-dev
     fi
 }
 


### PR DESCRIPTION
I removed libglpk-dev installation.
Because this library of ubuntu 16.04 is unstable in numerical calculation.