### PR TITLE
Use sch-core from jrl-umi3218

### DIFF
--- a/getsource.sh
+++ b/getsource.sh
@@ -83,7 +83,7 @@ get_source_hrpsys-humanoid() {
 }
 
 get_source_sch-core() {
-    get_source "git clone --recursive ${GITHUB_LINK}mehdi-benallegue/sch-core" sch-core
+    get_source "git clone --recursive ${GITHUB_LINK}jrl-umi3218/sch-core" sch-core
 }
 
 get_source_savedbg() {


### PR DESCRIPTION
Both `mc_rtc` and the `drcutil` scripts install sch-core as part of their dependencies. If they are not synchronized, this creates linking issues between the two environments (it was no longer compatible due to https://github.com/jrl-umi3218/sch-core/pull/35). I checked with @mehdi-benallegue, and there is no longer any reason not to use the jrl-umi3218 master instead.

Thus this PR changes the default clone path to jrl-umi3218 version. However, the script does not change the remote for already cloned repositories. For now we have synchronized the two master branches.