### PR TITLE
[config.sh.hrp5p01v] install sch-core in hrp5p01v

### DIFF
--- a/config.sh.hrp5p01v
+++ b/config.sh.hrp5p01v
@@ -6,7 +6,7 @@ export SUDO=
 export MAKE_THREADS_NUMBER=4
 export BUILD_TYPE=RelWithDebInfo
 export ROBOT_HOSTNAME=hrp5p01c.local
-export PACKAGES="OpenRTM-aist openhrp3 hrpsys-base HRP5P hmc2 hrpsys-humanoid"
+export PACKAGES="OpenRTM-aist openhrp3 hrpsys-base HRP5P sch-core hmc2 hrpsys-humanoid"
 
 ######## Please don't edit from here ########
 source definitions.sh


### PR DESCRIPTION
Fix the following error when executing `install.sh` in `hrp5p01v` with Ubuntu 18.04.

```bash
[  9%] Building CXX object CMakeFiles/hmc2.dir/src/MotionCommandSolver/CollisionPairs/PointPlanePairCreator.o
[  9%] Building CXX object CMakeFiles/hmc2.dir/src/MotionCommandSolver/CollisionPairs/SpherePlanePairCreator.o
[  9%] Building CXX object CMakeFiles/hmc2.dir/src/MotionCommandSolver/CollisionPairs/DistanceConstraintCreator.o
[  9%] Building CXX object CMakeFiles/hmc2.dir/src/MotionCommandSolver/ConstraintsCommon/WaistTransformEqualityConstraintBase.o
[ 10%] Building CXX object CMakeFiles/hmc2.dir/src/MotionCommandSolver/ConstraintsCommon/FootTransformEqualityConstraintBase.o
[ 10%] Building CXX object CMakeFiles/hmc2.dir/src/MotionCommandSolver/ConstraintsCommon/GeneralTransformEqualityConstraintBase.o
[ 10%] Building CXX object CMakeFiles/hmc2.dir/src/MotionCommandSolver/ConstraintsCommon/ComEqualityConstraintBase.o
[ 10%] Building CXX object CMakeFiles/hmc2.dir/src/MotionCommandSolver/ConstraintsCommon/MomentumEqualityConstraintBase.o
[ 10%] Building CXX object CMakeFiles/hmc2.dir/src/MotionCommandSolver/ConstraintsCommon/GazeEqualityConstraintBase.o
[ 10%] Building CXX object CMakeFiles/hmc2.dir/src/MotionCommandSolver/ConstraintsCommon/ConfigurationEqualityConstraintBase.o
[ 10%] Building CXX object CMakeFiles/hmc2.dir/src/MotionCommandSolver/ConstraintsCommon/CollisionAvoidanceInequalityConstraintBase.o
In file included from /home/hrp5puser/src/hmc2/src/MotionCommandSolver/ConstraintsCommon/CollisionAvoidanceInequalityConstraintBase.cpp:9:0:
/home/hrp5puser/src/hmc2/src/Solver/STP_BV.h:5:10: fatal error: sch/STP-BV/STP_BV.h: No such file or directory
 #include <sch/STP-BV/STP_BV.h>
          ^~~~~~~~~~~~~~~~~~~~~
compilation terminated.
CMakeFiles/hmc2.dir/build.make:2222: recipe for target 'CMakeFiles/hmc2.dir/src/MotionCommandSolver/ConstraintsCommon/CollisionAvoidanceInequalityConstraintBase.o' failed
make[2]: *** [CMakeFiles/hmc2.dir/src/MotionCommandSolver/ConstraintsCommon/CollisionAvoidanceInequalityConstraintBase.o] Error 1
make[2]: *** Waiting for unfinished jobs....
CMakeFiles/Makefile2:131: recipe for target 'CMakeFiles/hmc2.dir/all' failed
make[1]: *** [CMakeFiles/hmc2.dir/all] Error 2
Makefile:162: recipe for target 'all' failed
make: *** [all] Error 2
Error on line /home/hrp5puser/src/drcutil/install.sh:57
Stopping the script install.sh.
```