### PR TITLE
Clean OpenRTM-aist deeper

### DIFF
--- a/clean.sh
+++ b/clean.sh
@@ -3,7 +3,7 @@
 source config.sh
 
 cd $SRC_DIR/OpenRTM-aist
-make maintainer-clean
+make maintainer-clean && rm configure
 rm -rf $SRC_DIR/openhrp3/$BUILD_SUBDIR
 rm -rf $SRC_DIR/HRP2/$BUILD_SUBDIR
 rm -rf $SRC_DIR/HRP2KAI/$BUILD_SUBDIR


### PR DESCRIPTION
The previous clean was causing problems when rebuilding on Devian Buster (an included file was not found). This new clean would trigger a new autoconf generation.