### PR TITLE
[setupenv.sh] add dependency on libyaml-cpp-dev for hmc2

### DIFF
--- a/setupenv.sh
+++ b/setupenv.sh
@@ -98,7 +98,7 @@ setupenv_hmc2() {
     if [ $OSNAME = "Darwin" ]; then
 	brew install libyaml
     else
-	sudo apt-get -y install libyaml-dev libncurses5-dev libglpk-dev
+	sudo apt-get -y install libyaml-cpp-dev libyaml-dev libncurses5-dev libglpk-dev
     fi
 }
 


### PR DESCRIPTION
libyaml-cpp-dev is required to build hmc2 from https://github.com/isri-aist/hmc2/commit/00eb76f318e0ebd9f27f205b6c343c55a8d43f41