### PR TITLE
Add libyaml-cpp-dev to setupenv.sh

### DIFF
--- a/setupenv.sh
+++ b/setupenv.sh
@@ -128,9 +128,9 @@ setupenv_state-observation() {
 
 setupenv_hmc2() {
     if [ $OSNAME = "Darwin" ]; then
-	brew install libyaml
+	brew install libyaml libglpk
     else
-	sudo apt-get -y install libyaml-dev libncurses5-dev
+	sudo apt-get -y install libglpk-dev libyaml-dev libncurses5-dev
     fi
 }
 


### PR DESCRIPTION
Add install package libyaml-cpp-dev in setupenv.sh

Since https://github.com/isri-aist/hmc2/commit/00eb76f318e0ebd9f27f205b6c343c55a8d43f41,
libyaml-cpp-dev is used in hmc2.